### PR TITLE
Fix issue 3078

### DIFF
--- a/functions.coffee
+++ b/functions.coffee
@@ -1456,7 +1456,7 @@ exports.SETASSIGNMENT = (user) ->
 
 exports.SETCHOICEFILTER = (dataName, value) ->
   filterValue = if value?
-    _.chain([value]).flatten().compact().map(String).value()
+    _.chain([value]).flatten().compact().map(String).uniq().value()
   else
     null
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1949,3 +1949,7 @@ describe "SETCHOICEFILTER", ->
   it 'accepts null and does not return an array', ->
     SETCHOICEFILTER('choice_field', null)
     shouldBeNull(runtime.results[0].value)
+
+  it 'does not return duplicate results', ->
+    SETCHOICEFILTER('choice_field', [1, 1] )
+    runtime.results[0].value.should.eql '["1"]'


### PR DESCRIPTION
Issue #3078 
Addressed issue 3078 in fulcrum repo where `SETCHOICEFILTER( )` returns duplicate values when an array containing duplicate or similar filters are passed in.

Fix
Added `.uniq( )` function call to `SETCHOICEFILTER( )` to remove duplicates. Also added a test to test.coffee file. 