### PR TITLE
Implement DATEADD fix for daylight savings

### DIFF
--- a/functions.coffee
+++ b/functions.coffee
@@ -264,19 +264,16 @@ exports.DATE = (year, month, day) ->
 
   new Date("#{year}/#{month}/#{day} 00:00:00")
 
-exports.DATEADD = (date, number, type='day') ->
+exports.DATEADD = (date, number) ->
   date = DATEVALUE(date)
   number = INT(number)
 
   return NO_VALUE unless date?
   return NO_VALUE if ISNAN(number)
 
-  return NO_VALUE unless type is 'day'
+  date.setTime(date.getTime() + number)
 
-  time = date.getTime()
-  time += (number * (1000 * 60 * 60 * 24))
-
-  new Date(time)
+  date
 
 exports.DATEVALUE = (dateString, timeString) ->
   if _.isDate(dateString)


### PR DESCRIPTION
Changes the way `DATEADD` function calculates dates to make it more daylight savings friendly. Based off of how date-fns implements its `addDays` method: https://github.com/date-fns/date-fns/blob/master/src/addDays/index.js#L33-L35

Also removes unnecessary`type` parameter. Not only did `type` force a no-op if any value besides the default `"days"` was added, it wasn't even mentioned in our online documentation. 