### PR TITLE
[FLCRM-10300] Add ButtonField as a possible target for the click event

### DIFF
--- a/functions.coffee
+++ b/functions.coffee
@@ -1196,7 +1196,7 @@ validateEventParams = (event, param) ->
     when 'click'
       field = FIELD(param)
 
-      invariant(field?.type is 'HyperlinkField')
+      invariant(field?.type in ['HyperlinkField', 'ButtonField'])
 
     when 'load-repeatable', 'new-repeatable', 'edit-repeatable', 'save-repeatable', 'validate-repeatable'
       field = FIELD(param)


### PR DESCRIPTION
Add ButtonField as a possible target for the click event. 

They need it in mobile for the new task UX flows.

https://fulcrumapp.atlassian.net/browse/FLCRM-10300

Tested that HyperLink field still works on web by adding this on data events and making sure it shows the alert:

```
ON("click", 'hyperlink_test', function(event) {
  ALERT("Hyperlink clicked");
});
```
