### PR TITLE
FLCRM-10819 Add OPENEXTENSION function

### DIFF
--- a/functions.coffee
+++ b/functions.coffee
@@ -1253,19 +1253,29 @@ exports.OPENURL = (value) ->
 
   $$runtime.results.push(type: 'open', value: JSON.stringify(value))
 
-exports.OPENEXTENSION = (params) ->
-  if _.isString(params)
-    params = { url: params }
+exports.nextExtensionSessionID = 0
+exports.extensionMessageHandlers = {}
 
-  return ERROR('A url must be provided to OPENEXTENSION') unless _.isString(params.url)
+exports.OPENEXTENSION = (options) ->
+  ERROR('options must be provided') unless _.isObject(options)
+  ERROR('url must be provided') unless _.isString(options.url)
+  ERROR('onMessage function must be provided') unless _.isFunction(options.onMessage)
+
+  sessionID = ++exports.nextExtensionSessionID
+
+  onMessage = (message) ->
+    options.onMessage(message)
+    delete exports.extensionMessageHandlers[sessionID] if message.close is true
+
+  exports.extensionMessageHandlers[sessionID] = onMessage
 
   value =
-    url: params.url
-    title: if params.title? then params.title.toString() else null
-    data: if params.data? then params.data else null
-    width: if _.isNumber(params.width) then params.width else null
-    height: if _.isNumber(params.height) then params.height else null
-
+    id: sessionID
+    url: options.url
+    title: if options.title? then options.title.toString() else null
+    data: if options.data? then options.data else null
+    width: if _.isNumber(options.width) then options.width else null
+    height: if _.isNumber(options.height) then options.height else null
 
   $$runtime.results.push(type: 'open-extension', value: JSON.stringify(value))
 

--- a/runtime.coffee
+++ b/runtime.coffee
@@ -190,6 +190,9 @@ class Runtime
 
     `with (this.variables) { eval(script) }`
 
+    ON 'extension-message', (event) =>
+      functions.extensionMessageHandlers[event.id]?(event)
+
     return
 
   hookName: (name) ->
@@ -357,6 +360,7 @@ class Runtime
       OFF: true
       ON: true
       OPENURL: true
+      OPENEXTENSION: true
       PROGRESS: true
       REQUEST: true
       SETCHOICEFILTER: true

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -896,6 +896,18 @@ describe 'ODD', ->
     ODD(new Date).should.be.NaN
     ODD().should.be.NaN
 
+describe 'OPENEXTENSION', ->
+  it 'accepts a url', ->
+    OPENEXTENSION(url: 'https://test.com', onMessage: ->)
+
+    JSON.parse(runtime.results[0].value).url.should.eql 'https://test.com'
+
+  it 'requires a url', ->
+    (-> OPENEXTENSION({})).should.throw('url must be provided');
+
+  it 'requires an onMessage handler', ->
+    (-> OPENEXTENSION(url: 'https://test.com')).should.throw('onMessage function must be provided');
+
 describe 'OR', ->
   it 'returns true if any argument is truthy', ->
     OR(true, false).should.be.true


### PR DESCRIPTION
Add an OPENEXTENSION function in order to open an extension in an iframe.

##Testing

Download https://gist.githubusercontent.com/zhm/c7a30a953ce16d79f0bd5adca95e8626/raw/c45c99e367940438d1809cdc78d2813c83521bab/index.html to some folder.

In that folder, run `python3 -m http.server 9191` to expose this as localhost.

Go to https://rails7274.thefulcrum.team/dash/4c2234be-4487-48c8-8503-864cd67581ab

This environment is setup to use this version of Fulcrum Expressions. Open a record editor and click on select state. It should open the state picker in an iframe. Click on a state and the state name should appear in the record editor.

We are just testing Fulcrum Expressions here, not the Fulcrum code. This is the test expression:

https://gist.githubusercontent.com/zhm/c7a30a953ce16d79f0bd5adca95e8626/raw/c45c99e367940438d1809cdc78d2813c83521bab/data-event.js