### PR TITLE
FLCRM-16760 Add "limit", "offset", "order" and "where" arguments for LOADRECORDS

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ To deploy to your user's preview environment:
 aws sso login (or however you login to the chaos aws account)
 yarn deploy
 ```
-(Remember to update fulcrum's config to point at your S3 bucket's files)
+You will need to update fulcrum's config to point at your S3 bucket's files. The
+[skaffold.yaml file in fulcrum](https://github.com/fulcrumapp/fulcrum/blob/main/skaffold.yaml)
+has a configuration for the "fulcrum.rails.config.expression_sandbox_url" value which can
+be uncommented.
 
 To deploy to production (requires fulcrum production access):
 ```sh

--- a/functions.coffee
+++ b/functions.coffee
@@ -1258,12 +1258,9 @@ exports.LOADRECORDS = (options, callback) ->
   ERROR('options.form_id must be a string') if options.form_id and not _.isString(options.form_id)
   ERROR('options.form_name must be a string') if options.form_name and not _.isString(options.form_name)
   ERROR('options.limit must be a number') if options.limit and not _.isNumber(options.limit)
-  ERROR('options.sort must be an object') if options.sort and not _.isObject(options.sort)
-  ERROR('options.sort.data_names must be an array') if options.sort and options.sort.data_names and not _.isArray(options.sort.data_names)
-  ERROR('options.sort.data_names must be strings') if options.sort and options.sort.data_names and not _.every(options.sort.data_names, _.isString)
-  ERROR('options.sort.direction must be a string ') if options.sort and options.sort.direction and not _.isString(options.sort.direction)
-  ERROR('options.where_clauses must be an array') if options.where_clauses and not _.isArray(options.where_clauses)
-  ERROR('options.where_clauses must be strings') if options.where_clauses and not _.every(options.where_clauses, _.isString)
+  ERROR('options.offset must be a number') if options.offset and not _.isNumber(options.offset)
+  ERROR('options.order must be a string or array') if options.order and not (_.isString(options.order) or _.isArray(options.order))
+  ERROR('options.where must be a string or object') if options.where and not (_.isString(options.where) or _.isObject(options.where))
   ERROR('callback must be a function') if callback and not _.isFunction(callback)
 
   callback ?= () ->
@@ -1273,8 +1270,9 @@ exports.LOADRECORDS = (options, callback) ->
     form_id: if options.form_id? then options.form_id.toString() else null
     form_name: if options.form_name? then options.form_name.toString() else null
     limit: if options.limit? then options.limit else null
-    sort: if options.sort? then options.sort else null
-    where_clauses: if options.where_clauses? then options.where_clauses else []
+    offset: if options.offset? then options.offset else null
+    order: if options.order? then options.order else null
+    where: if options.where? then options.where else null
 
   completion = (error, result) =>
     callback(error, result)

--- a/functions.coffee
+++ b/functions.coffee
@@ -1258,6 +1258,12 @@ exports.LOADRECORDS = (options, callback) ->
   ERROR('options.form_id must be a string') if options.form_id and not _.isString(options.form_id)
   ERROR('options.form_name must be a string') if options.form_name and not _.isString(options.form_name)
   ERROR('options.limit must be a number') if options.limit and not _.isNumber(options.limit)
+  ERROR('options.sort must be an object') if options.sort and not _.isObject(options.sort)
+  ERROR('options.sort.data_names must be an array') if options.sort and options.sort.data_names and not _.isArray(options.sort.data_names)
+  ERROR('options.sort.data_names must be strings') if options.sort and options.sort.data_names and not _.every(options.sort.data_names, _.isString)
+  ERROR('options.sort.direction must be a string ') if options.sort and options.sort.direction and not _.isString(options.sort.data_names)
+  ERROR('options.where_clauses must be an array') if options.where_clauses and not _.isArray(options.where_clauses)
+  ERROR('options.where_clauses must be strings') if options.where_clauses and not _.every(options.where_clauses, _.isString)
   ERROR('callback must be a function') if callback and not _.isFunction(callback)
 
   callback ?= () ->
@@ -1267,6 +1273,9 @@ exports.LOADRECORDS = (options, callback) ->
     form_id: if options.form_id? then options.form_id.toString() else null
     form_name: if options.form_name? then options.form_name.toString() else null
     limit: if options.limit? then options.limit else null
+    sort: if options.sort? then options.sort else null
+    where_clauses: if options.where_clauses? then options.where_clauses else []
+
   completion = (error, result) =>
     callback(error, result)
 

--- a/functions.coffee
+++ b/functions.coffee
@@ -1257,6 +1257,7 @@ exports.LOADRECORDS = (options, callback) ->
   ERROR('options.ids must be an array') if options.ids and not _.isArray(options.ids)
   ERROR('options.form_id must be a string') if options.form_id and not _.isString(options.form_id)
   ERROR('options.form_name must be a string') if options.form_name and not _.isString(options.form_name)
+  ERROR('options.limit must be a number') if options.limit and not _.isNumber(options.limit)
   ERROR('callback must be a function') if callback and not _.isFunction(callback)
 
   callback ?= () ->
@@ -1265,7 +1266,7 @@ exports.LOADRECORDS = (options, callback) ->
     ids: if options.ids? then options.ids else []
     form_id: if options.form_id? then options.form_id.toString() else null
     form_name: if options.form_name? then options.form_name.toString() else null
-
+    limit: if options.limit? then options.limit else null
   completion = (error, result) =>
     callback(error, result)
 

--- a/functions.coffee
+++ b/functions.coffee
@@ -1261,7 +1261,7 @@ exports.LOADRECORDS = (options, callback) ->
   ERROR('options.sort must be an object') if options.sort and not _.isObject(options.sort)
   ERROR('options.sort.data_names must be an array') if options.sort and options.sort.data_names and not _.isArray(options.sort.data_names)
   ERROR('options.sort.data_names must be strings') if options.sort and options.sort.data_names and not _.every(options.sort.data_names, _.isString)
-  ERROR('options.sort.direction must be a string ') if options.sort and options.sort.direction and not _.isString(options.sort.data_names)
+  ERROR('options.sort.direction must be a string ') if options.sort and options.sort.direction and not _.isString(options.sort.direction)
   ERROR('options.where_clauses must be an array') if options.where_clauses and not _.isArray(options.where_clauses)
   ERROR('options.where_clauses must be strings') if options.where_clauses and not _.every(options.where_clauses, _.isString)
   ERROR('callback must be a function') if callback and not _.isFunction(callback)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fulcrum-expressions",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Expression runtime for Fulcrum",
   "author": "Fulcrum",
   "license": "BSD-3-Clause",

--- a/ts/api.ts
+++ b/ts/api.ts
@@ -3459,16 +3459,29 @@ interface LoadRecordsOptions {
      */
     limit?: number;
     /**
-     * The sort order.
+     * The offset of the records to return.
      */
-    sort?: {
-        data_names: string[];
-        direction: 'asc' | 'desc';
-    };
+    offset?: number;
     /**
-     * The where clauses to filter the records. These should be in the form "data_name = 'value'".
+     * The sort order. Either a string or an array like "order: [['data_name_1', 'asc'], ['data_name_2', 'desc']]"
      */
-    where_clauses?: string[];
+    order?: string | string[][];
+    /**
+     * The where clauses to filter the records. Either a string or an object like
+     * "where: {
+     *   operator: 'and',
+     *   predicates: [
+     *    { field_name: 'data_name_1', operator: 'contains', value: 'value' }
+     *    { field_name: 'data_name_2', operator: 'contains', value: 'value' }
+     *    { operator: 'or',
+     *      predicates: [
+     *        { field_name: 'data_name_3', operator: 'contains', value: 'value' }
+     *      ]
+     *    }
+     *  ]
+     * }
+     */
+    where?: string | { operator: string, predicates: any[]};
 }
 interface RecordAttributes {
     id: string;

--- a/ts/api.ts
+++ b/ts/api.ts
@@ -3481,7 +3481,10 @@ interface LoadRecordsOptions {
      *  ]
      * }
      */
-    where?: string | { operator: string, predicates: any[]};
+    where?: string | {
+      operator: string;
+      predicates: any[];
+    };
 }
 interface RecordAttributes {
     id: string;

--- a/ts/api.ts
+++ b/ts/api.ts
@@ -3458,6 +3458,17 @@ interface LoadRecordsOptions {
      * The maximum number of records to return.
      */
     limit?: number;
+    /**
+     * The sort order.
+     */
+    sort?: {
+        data_names: string[];
+        direction: 'asc' | 'desc';
+    };
+    /**
+     * The where clauses to filter the records. These should be in the form "data_name = 'value'".
+     */
+    where_clauses?: string[];
 }
 interface RecordAttributes {
     id: string;

--- a/ts/api.ts
+++ b/ts/api.ts
@@ -3454,6 +3454,10 @@ interface LoadRecordsOptions {
      * The form name that contains the records. If no form_id or form_name is passed, the current form_id is used.
      */
     form_name?: string;
+    /**
+     * The maximum number of records to return.
+     */
+    limit?: number;
 }
 interface RecordAttributes {
     id: string;

--- a/ts/api.ts
+++ b/ts/api.ts
@@ -3463,27 +3463,27 @@ interface LoadRecordsOptions {
      */
     offset?: number;
     /**
-     * The sort order. Either a string or an array like "order: [['data_name_1', 'asc'], ['data_name_2', 'desc']]"
-     */
+   * The sort order. Either a string or an array like "order: [['data_name_1', 'asc'], ['data_name_2', 'desc']]"
+   */
     order?: string | string[][];
     /**
-     * The where clauses to filter the records. Either a string or an object like
-     * "where: {
-     *   operator: 'and',
-     *   predicates: [
-     *    { field_name: 'data_name_1', operator: 'contains', value: 'value' }
-     *    { field_name: 'data_name_2', operator: 'contains', value: 'value' }
-     *    { operator: 'or',
-     *      predicates: [
-     *        { field_name: 'data_name_3', operator: 'contains', value: 'value' }
-     *      ]
-     *    }
-     *  ]
-     * }
-     */
+    * The where clauses to filter the records. Either a string or an object like
+    * "where: {
+    *   operator: 'and',
+    *   predicates: [
+    *    { field_name: 'data_name_1', operator: 'contains', value: 'value' }
+    *    { field_name: 'data_name_2', operator: 'contains', value: 'value' }
+    *    { operator: 'or',
+    *      predicates: [
+    *        { field_name: 'data_name_3', operator: 'contains', value: 'value' }
+    *      ]
+    *    }
+    *  ]
+    * }
+    */
     where?: string | {
-      operator: string;
-      predicates: any[];
+        operator: string;
+        predicates: any[];
     };
 }
 interface RecordAttributes {

--- a/ts/functions/LOADRECORDS.ts
+++ b/ts/functions/LOADRECORDS.ts
@@ -24,16 +24,29 @@ interface LoadRecordsOptions {
    */
   limit?: number;
   /**
-   * The sort order.
+   * The offset of the records to return.
    */
-  sort?: {
-    data_names: string[];
-    direction: 'asc' | 'desc';
-  };
+  offset?: number;
+    /**
+   * The sort order. Either a string or an array like "order: [['data_name_1', 'asc'], ['data_name_2', 'desc']]"
+   */
+  order?: string | string[][];
   /**
-   * The where clauses to filter the records. These should be in the form "data_name = 'value'".
-   */
-  where_clauses?: string[];
+  * The where clauses to filter the records. Either a string or an object like
+  * "where: {
+  *   operator: 'and',
+  *   predicates: [
+  *    { field_name: 'data_name_1', operator: 'contains', value: 'value' }
+  *    { field_name: 'data_name_2', operator: 'contains', value: 'value' }
+  *    { operator: 'or',
+  *      predicates: [
+  *        { field_name: 'data_name_3', operator: 'contains', value: 'value' }
+  *      ]
+  *    }
+  *  ]
+  * }
+  */
+  where?: string | { operator: string, predicates: any[]};
 }
 
 interface RecordAttributes {

--- a/ts/functions/LOADRECORDS.ts
+++ b/ts/functions/LOADRECORDS.ts
@@ -23,6 +23,17 @@ interface LoadRecordsOptions {
    * The maximum number of records to return.
    */
   limit?: number;
+  /**
+   * The sort order.
+   */
+  sort?: {
+    data_names: string[];
+    direction: 'asc' | 'desc';
+  };
+  /**
+   * The where clauses to filter the records. These should be in the form "data_name = 'value'".
+   */
+  where_clauses?: string[];
 }
 
 interface RecordAttributes {

--- a/ts/functions/LOADRECORDS.ts
+++ b/ts/functions/LOADRECORDS.ts
@@ -19,6 +19,10 @@ interface LoadRecordsOptions {
    * The form name that contains the records. If no form_id or form_name is passed, the current form_id is used.
    */
   form_name?: string;
+  /**
+   * The maximum number of records to return.
+   */
+  limit?: number;
 }
 
 interface RecordAttributes {


### PR DESCRIPTION
# What

- Adds optional arguments to "limit", "offset", "order" and filter with "where" clauses, in the LOADRECORDS data event function
- Allows calls like: 

```
  // Using simple syntax
  LOADRECORDS(
    {
      form_name: $form_name, 
      limit: $number, 
      offset: 1,
      order: "foobar", "ASC",
      where: `foobar = ${$name} and wizbang < 3`
    }, 
    function(error, results) {}
  )

  // Using full syntax
  LOADRECORDS(
    {
      form_name: $form_name, 
      limit: $number, 
      offset: 1,
      order: [["foobar", "ASC"], ["blah", "DESC"]],
      where: {
        operator: "and",
        predicates: [
          {field_key: "foobar", operator: "contains", value: "blah"}
          {field_key: "wizbang", operator: "equal_to", value: 7}
        ]
      }
    }, 
    function(error, results) {}
  )
```

# Why

https://fulcrumapp.atlassian.net/browse/FLCRM-16760

# Post merge requirements

After this PR is merged, we need to
- Do a `yarn deploy` to Production (for web)
- Publish version "2.1.1" to NPM (for mobile)

# Testing

This PR makes the arguments available, but those arguments are ignored by the current LOADRECORDS logic. A custom version of Fulcrum (which will _not_ be merged) exposes information we'd normally not be able to examine, and adds some sample functionality (mostly for dramatic effect). For more on why this testing approach is valid, take a look at the "Deep dive" section below

### Setup
A preview environment was created for this PR which is accessible at [https://expressions78.thefulcrum.team](https://expressions78.thefulcrum.team). Here are the steps taken to set it up:

- Environment level
  - From within the code for this PR:
    - Run ``USER=expression78 yarn deploy`
    - This gets fulcrum-expression into S3
  - From within a [specific branch of fulcrum](https://github.com/fulcrumapp/fulcrum/pull/9391), created solely for testing this PR:
    - Run `USER=expression78 skaffold run` (this didn't go as smoothly as I had hoped, but it seems to be working now - see the comments in the ticket for more on that)
    - This gets fulcrum-expressions into fulcrum-components
- Org level
  - Create an App with a bunch of Records
    - Name it "My everything app" to work with the attached App
    - I tweaked this in the preview environment (so don't be confused why it's now "My other app")
  - Import the "Data Events Tester" App
    - Unzip the file to reveal the ".fulcrumapp" file
    - Provide that file to the form on `https://expressions78.thefulcrum.team/apps/import`

[DataEventTester.zip](https://github.com/user-attachments/files/18116299/DataEventTester.zip)

### The test
Again, we're just ensuring that _if_ we define a LOADRECORDS data event with "limit", "offset", "order" or "where", they'll show up where they're supposed to. 

- Be sure to have your browser console open
  - You should be able to limit output to just "info" messages to reduce some of the noise
- Go into "Edit App" of the "Data Events Tester App"
- Once loaded, click on the "Data Events (Enabled)" button
- From within the Data Event Editor:
  - Note the LOADRECORDS function and it's arguments
  - Click the "Preview App" button
  - Once the Record Editor loads, press the "Click to load" link
- A custom "OPTIONS" console.log messages reveals the "LoadRecordOptions" arguments available for evaluation
  - Verify "limit", "offset", "order" and "where" arguments are present
  - Verify the values match what you expect, based on the LOADRECORDS definition
  - You can change the "Number of Records to load" value on the form to change "limit"
  - Clicking "Click to load" again will show "OPTIONS" again, this time with whatever you entered in the field
- Go back to the Data Event Editor and change the LOADRECORDS function arguments
- Preview the updated data events
  - Verify the "OPTIONS" output is as expected
  - Repeat with different arguments in the Data Events Editor
    - If you put in a `4` where a (string | string[][]) is expected, the event will fail (as expected)
    - If you add arguments not expected, they'll just get dropped on the floor
    - Note that the type checking of "order" and "where" structures (when they're not strings) is not exhaustively validated (it will be up to each platform to implement their HostFunction defensively)

Here's an example from the preview environment:

https://github.com/user-attachments/assets/88a46a53-d6f0-4eee-b874-a16b31f51c18

### Deep dive into fulcrum-expressions
The `fulcrum-expressions` code runs in javascript (within the expression engine) each time a Record change is detected. While some functions can be executed solely in javascript, others must be executed in their native environment (i.e. browser or device), which is the case with LOADRECORDS. In this case, we need to read from either the Query service for the browser, or an embedded database on the mobile device.

In cases like LOADRECORDS, fulcrum-expressions passes control onto a "HostFunction" to do the actual looking up of Records. The part that we're adding in this PR is to allow the additional arguments to be passed from the expression engine into the HostFunction.