### PR TITLE
add typing for loadfileoption variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fulcrum-expressions",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Expression runtime for Fulcrum",
   "author": "Fulcrum",
   "license": "BSD-3-Clause",

--- a/ts/api.ts
+++ b/ts/api.ts
@@ -3375,6 +3375,10 @@ interface LoadFileOptions {
      * The form name that contains the reference file. If no form_id or form_name is passed, the current form_id is used.
      */
     form_name?: string;
+    /**
+     * The name of the global variable to initialize with the content of the loaded file.
+     */
+    variable?: string;
 }
 declare function LOADFILE(options: LoadFileOptions, callback: (error: Error, result: any) => void): void;
 

--- a/ts/functions/LOADFILE.ts
+++ b/ts/functions/LOADFILE.ts
@@ -21,6 +21,10 @@ interface LoadFileOptions {
    * The form name that contains the reference file. If no form_id or form_name is passed, the current form_id is used.
    */
   form_name?: string;
+  /**
+   * The name of the global variable to initialize with the content of the loaded file.
+   */
+  variable?: string;
 }
 
 export default function LOADFILE(


### PR DESCRIPTION
add loadfileoption variable to type so it doesn't throw errors in data events editor

see https://docs.fulcrumapp.com/docs/data-events-loadfile

<img width="1070" alt="Screenshot 2025-01-02 at 10 22 55 AM" src="https://github.com/user-attachments/assets/a9a928cc-d866-4105-9aa4-8b2891562d7c" />
