### PR TITLE
Chore: Bump version from 2.1.6 to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fulcrum-expressions",
-  "version": "2.1.6",
+  "version": "2.2.0",
   "description": "Expression runtime for Fulcrum",
   "author": "Fulcrum",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
This pull request updates the package version in `package.json` to reflect new changes.

- Version bump:
  * Increased the package version from `2.1.6` to `2.2.0` in `package.json` to indicate a new minor release.